### PR TITLE
Enable Documenter preview deployments

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,4 +28,7 @@ makedocs(
     ],
 )
 
-deploydocs(repo = "github.com/QuantumSavory/AnythingLLMDocs.jl.git")
+deploydocs(
+    repo = "github.com/QuantumSavory/AnythingLLMDocs.jl.git",
+    push_preview = true,
+)


### PR DESCRIPTION
## Summary

- enable Documenter preview deployments for pull requests
- retain the existing documentation deployment target

## Validation

- `git diff --check`
- parsed `docs/make.jl` with Julia `Meta.parseall`