### PR TITLE
Skip documentation and changelog checks for Dependabot

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,7 @@ jobs:
 
   docs:
     name: Documentation
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ChangelogEnforcer.yml
+++ b/.github/workflows/ChangelogEnforcer.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   # Enforces the update of a changelog file on every pull request 
   changelog:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
     - uses: dangoslen/changelog-enforcer@v3


### PR DESCRIPTION
## Summary

- skip the Documenter and changelog jobs for Dependabot pull requests
- retain both checks for human-authored pull requests

## Validation

- `gh act -n --validate`
- workflow YAML parse and `git diff --check`