### PR TITLE
Skip Aqua in downgrade tests

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+env:
+  QUANTUMSAVORY_DOWNGRADE_TEST: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,10 @@ using AnythingLLMDocs
 using Aqua
 using Test
 
-@testset "Aqua" begin
-    Aqua.test_all(AnythingLLMDocs)
+if get(ENV, "QUANTUMSAVORY_DOWNGRADE_TEST", "") != "true"
+    @testset "Aqua" begin
+        Aqua.test_all(AnythingLLMDocs)
+    end
 end
 
 @testset "Configuration and embed defaults" begin


### PR DESCRIPTION
Summary:
- mark downgrade jobs with the shared environment variable
- skip Aqua while retaining the behavioral tests

Validation:
- parsed the Julia test entry point
- checked normal and downgrade guard behavior
- parsed the workflow YAML
- ran git diff --check